### PR TITLE
formal: Fix to make formal verification for dpram run

### DIFF
--- a/rtl/verilog/mor1kx_simple_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_simple_dpram_sclk.v
@@ -71,7 +71,7 @@ endgenerate
 
 /*-----Formal checking------*/ 
 
-`ifdef Formal
+`ifdef FORMAL
 
    always @(posedge clk)begin
        //On clear, all memory contents should be initialized to zero


### PR DESCRIPTION
This fixes the formal code, but introduces the following failure:

Please have a look.

```
< shorne@antec ~/work/openrisc/local-cores/mor1kx > make -C bench/formal -s mor1kx_simple_dpram_sclk | tail
make: *** [Makefile:28: mor1kx_simple_dpram_sclk] Error 2
SBY 19:45:09 [mor1kx_simple_dpram_sclk] engine_0.induction: ##   0:00:00  Writing trace to constraints file: engine_0/trace_induct.smtc
SBY 19:45:09 [mor1kx_simple_dpram_sclk] engine_0.induction: ##   0:00:00  Status: failed
SBY 19:45:09 [mor1kx_simple_dpram_sclk] engine_0.induction: finished (returncode=1)
SBY 19:45:09 [mor1kx_simple_dpram_sclk] engine_0: Status returned by engine for induction: FAIL
SBY 19:45:09 [mor1kx_simple_dpram_sclk] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:00 (0)
SBY 19:45:09 [mor1kx_simple_dpram_sclk] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:00 (0)
SBY 19:45:09 [mor1kx_simple_dpram_sclk] summary: engine_0 (smtbmc yices) returned FAIL for basecase
SBY 19:45:09 [mor1kx_simple_dpram_sclk] summary: counterexample trace: mor1kx_simple_dpram_sclk/engine_0/trace.vcd
SBY 19:45:09 [mor1kx_simple_dpram_sclk] summary: engine_0 (smtbmc yices) returned FAIL for induction
SBY 19:45:09 [mor1kx_simple_dpram_sclk] DONE (FAIL, rc=2)

```