### PR TITLE
formal: Add test for true_dpram with bypass disabled, fix formal

### DIFF
--- a/bench/formal/Makefile
+++ b/bench/formal/Makefile
@@ -12,7 +12,8 @@
 ##########################################################$
 
 TESTS := mor1kx_cache_lru \
-	mor1kx_simple_dpram_sclk \
+	mor1kx_simple_dpram_sclk-enable_bypass \
+	mor1kx_simple_dpram_sclk-disable_bypass \
 	mor1kx_true_dpram_sclk \
 	mor1kx_icache
 
@@ -24,5 +25,5 @@ clean:
 
 RTL := ../../rtl/verilog
 
-$(TESTS): % : $(RTL)/%.v
+$(TESTS): % :
 	sby -f $@.sby

--- a/bench/formal/mor1kx_simple_dpram_sclk-disable_bypass.sby
+++ b/bench/formal/mor1kx_simple_dpram_sclk-disable_bypass.sby
@@ -1,0 +1,17 @@
+[options]
+mode prove
+depth 50
+wait on
+
+[engines]
+smtbmc yices
+
+[script]
+
+read -formal mor1kx_simple_dpram_sclk.v
+chparam -set ENABLE_BYPASS 0 mor1kx_simple_dpram_sclk
+chparam -set CLEAR_ON_INIT 1 mor1kx_simple_dpram_sclk
+prep -top mor1kx_simple_dpram_sclk
+
+[files]
+../../rtl/verilog/mor1kx_simple_dpram_sclk.v

--- a/bench/formal/mor1kx_simple_dpram_sclk-enable_bypass.sby
+++ b/bench/formal/mor1kx_simple_dpram_sclk-enable_bypass.sby
@@ -9,6 +9,8 @@ smtbmc yices
 [script]
 
 read -formal mor1kx_simple_dpram_sclk.v
+chparam -set ENABLE_BYPASS 1 mor1kx_simple_dpram_sclk
+chparam -set CLEAR_ON_INIT 1 mor1kx_simple_dpram_sclk
 prep -top mor1kx_simple_dpram_sclk
 
 [files]

--- a/rtl/verilog/mor1kx_simple_dpram_sclk.v
+++ b/rtl/verilog/mor1kx_simple_dpram_sclk.v
@@ -70,7 +70,7 @@ endgenerate
    end
 
 /*-----Formal checking------*/
- 
+
 `ifdef FORMAL
 
    reg t_past_ctrl;
@@ -85,7 +85,7 @@ endgenerate
         assert (dout == $past(din));
 
       if ($past(we) & t_past_ctrl & !ENABLE_BYPASS)
-        assert (mem[waddr] == $past(din));
+        assert (mem[$past(waddr)] == $past(din));
 
       if ($past(re) & t_past_ctrl & !ENABLE_BYPASS)
         assert (dout == $past(mem[raddr]));


### PR DESCRIPTION
The FORMAL test does not run with BYPASS disabled unless we specify it in our .sby file.  Add a new sby file to be able to test with BYPASS disabled.  Also this uncovered an issue with the formal verification, so fix that.